### PR TITLE
fix: image circleCi not found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
 
     # circleciが建てるdocker imageの種類
     docker:
-      - image: circleci/node:14-slim
+      - image: circleci/node:14
 
     # deployというjobを行うためにcircleciのdocker内で動作させるコマンド
     steps:


### PR DESCRIPTION
# Why
circleCi node version not found
# What
move to circleci node:14 